### PR TITLE
Add missing extension that adds toggling support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ line-length = 88
 target-version = ['py36', 'py37']
 
 [tool.portray.mkdocs]
-markdown_extensions =["admonition"]
+markdown_extensions =["admonition", "pymdownx.details"]
 repo_name = "lpfann/fri"
 repo_url = "https://github.com/lpfann/fri"
 


### PR DESCRIPTION
Hi @lpfann,

This pull request should fix the show source toggles on your documentation website, as mentioned in [this ticket](https://github.com/timothycrosley/portray/issues/40).

By default, portray enables a [variety of markdown extensions](https://github.com/timothycrosley/portray/blob/38cf2badac58f20ddbdd11b9637a43a65bc5d093/portray/config.py#L28) with this extension in particular being responsible for the source block toggling.

Another option, if you wish or need to avoid this extension for any reason, would be to disable source inclusion in your documentation via the following settings:

```toml
[tool.portray.pdocs]
exclude_source = true
```

Hope this helps! 

Thanks!

~Timothy